### PR TITLE
Make it possible to poll every X seconds, instead of indefinitely

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ module.exports = function(options) {
 		});
 	};
 
-	var pullIntervalSeconds = options.pullIntervalSeconds || 2;
+	var wait = options.wait || 2000;
 
 	that.pull = function(name, workers, onmessage) {
 		if (typeof workers === 'function') return that.pull(name, options.workers || 1, workers);
@@ -142,16 +142,11 @@ module.exports = function(options) {
 
 				queueURL(name, function(url) {
 					req(queryURL('ReceiveMessage', url, {WaitTimeSeconds:20}), function(err, res) {
-						if (err || res.statusCode !== 200) {
-							return setTimeout(next, pullIntervalSeconds * 1000);
-						}
+						if (err || res.statusCode !== 200) return setTimeout(next, wait);
 
 						var body = text(res.body, 'Body');
 
-						if (!body)
-							return options.pullIntervalSeconds
-								? setTimeout(next, pullIntervalSeconds * 1000)
-								: next();
+						if (!body) return options.wait ? setTimeout(next, wait) : next();
 
 						var receipt = text(res.body, 'ReceiptHandle');
 


### PR DESCRIPTION
By introducing an options pullIntervalSeconds, users can opt to poll SQS
less frequently. For instance, if set to 60, we will wait 60 seconds after
we get a response from SQS before starting a new poll request.

If the option is not set, it should work as before, so this is an opt-in
feature for people who might care about the number of SQS requests they
use.
