### PR TITLE
Include Amazon's error message when possible.

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,11 @@ module.exports = function(options) {
 		request(queryURL('CreateQueue', '/', {QueueName:name}), function(err) {
 			if (err) return onresult(err);
 			request(queryURL('GetQueueUrl', '/', {QueueName:name}), function(err, res) {
-				if (err || res.statusCode !== 200) return onresult(err || new Error('invalid status code from GetQueueUrl: '+res.statusCode));
+				if (err || res.statusCode !== 200) {
+					var errMessage = res.body ? text(res.body, 'Message') : '';
+					return onresult(err || new Error('invalid status code from GetQueueUrl: '+res.statusCode +
+							(errMessage? '. '+errMessage : '') ));
+				}
 				onresult(null, '/'+text(res.body, 'QueueUrl').split('/').slice(3).join('/'));
 			});
 		});


### PR DESCRIPTION
It seems that Amazon will return a helpful error message when things don't go as planned. This change attempts to pass that message through when an error is raised so that it's more obvious what went wrong.

E.g. an exception's message goes from:

```Error: invalid status code from GetQueueUrl: 400```
To
```Error: invalid status code from GetQueueUrl: 400. The specified queue does not exist or you do not have access to it.```