### PR TITLE
Add a configuration option to specify a host other than Amazon

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Create a queue instance. Available options are
 * `options.namespace` - Prefix all queues with `namespace`. Defaults to empty string.
 * `options.https` - If true use https. Defaults to false.
 * `options.raw` - If true it doesn't parse message's body to JSON. Defaults to false.
+* `options.host` - Overrides the AWS region, useful for testing. Defaults to false.
 
 Some of the options can be configured using env vars. See below for more.
 

--- a/index.js
+++ b/index.js
@@ -33,13 +33,14 @@ module.exports = function(options) {
 	options.secret = options.secret || process.env.SQS_SECRET_KEY;
 	options.region = options.region || process.env.SQS_REGION || DEFAULT_REGION;
 	options.raw = options.raw || false;
+	options.host = options.host || false;
 
 	if (!options.access || !options.secret) throw new Error('options.access and options.secret are required');
 
 	var queues = {};
 	var closed = false;
 	var proto = options.https ? 'https://' : 'http://';
-	var host = 'sqs.'+options.region+'.amazonaws.com';
+	var host = options.host || 'sqs.'+options.region+'.amazonaws.com';
 	var namespace = options.namespace ? options.namespace+'-' : '';
 
 	namespace = namespace.replace(/[^a-zA-Z0-9]/g, '-').replace(/\-+/g, '-');


### PR DESCRIPTION
Not married to defaulting `options.host` to `false`, but this was the only modification I needed to make to get this working with [https://github.com/iain/fake_sqs](https://github.com/iain/fake_sqs) which has been an incredible boon in testing.