### PR TITLE
Update request dependancy to 2.75.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sqs",
   "version": "2.0.1",
   "dependencies": {
-    "request": "~2.72.0"
+    "request": "~2.75.0"
   },
   "repository": "git://github.com/mafintosh/sqs",
   "description": "A message queue using Amazon Simple Queue Service.",


### PR DESCRIPTION
There is a security issues with tough-cookie@2.2.2 which is what request 2.72.0 is using.
See https://nodesecurity.io/advisories/130
and https://github.com/request/request/commit/4f03ea8a8399ef17f1d5c71defd08184d9cbdae3#diff-b9cfc7f2cdf78a7f4b91a753d10865a2
