### PR TITLE
Allows use of AWS profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 example.js
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(options) {
 	options.raw = options.raw || false;
 	options.proxy = options.proxy || false;
 
-	if ((!options.access || !options.secret) && !(!options.profile)) throw new Error('options.access and options.secret are required when options.profile is not set');
+	if ((!options.access || !options.secret) && (!options.profile)) throw new Error('options.access and options.secret are required when options.profile is not set');
 
 	if(options.profile) {
 		const credentials = new AWS.SharedIniFileCredentials({profile: options.profile});

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sqs",
   "version": "2.0.2",
   "dependencies": {
+    "aws-sdk": "^2.62.0",
     "request": "~2.75.0"
   },
   "repository": "git://github.com/mafintosh/sqs",


### PR DESCRIPTION
Credentials are loaded from ~/.aws/credentials if the AWS_PROFILE environment variable is set